### PR TITLE
Fix empty text width calculation

### DIFF
--- a/src/useTextWidth.tsx
+++ b/src/useTextWidth.tsx
@@ -44,7 +44,7 @@ const useTextWidth: useTextWidthType = (options) => {
       const metrics = context.measureText(refOptions.ref.current.textContent);
 
       return metrics.width;
-    } else if (textOptions?.text) {
+    } else if (textOptions?.text !== undefined) {
       return getTextWidth(textOptions.text, textOptions.font ?? '16px times');
     }
 


### PR DESCRIPTION
Currently when text is an empty string, hook `useTextWidth` returns NaN. I think it would be better to return 0 in this case.